### PR TITLE
Run `ember server` instead of `ember fastboot` in tests

### DIFF
--- a/lib/commands/fastboot-test.js
+++ b/lib/commands/fastboot-test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const VersionChecker = require('ember-cli-version-checker');
+
 module.exports = {
   name: 'fastboot:test',
   description: 'Run your Fastboot tests',
@@ -21,6 +23,9 @@ module.exports = {
   ],
 
   run(options) {
+    let checker = new VersionChecker(this);
+    checker.for('ember-cli-fastboot').assertAbove('1.0.0-beta.16');
+
     let TestTask = require('../tasks/test');
 
     let testTask = new TestTask({

--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -37,7 +37,7 @@ module.exports = CoreObject.extend({
     // Add each file to the mocha instance
     testFiles.forEach((file) => mocha.addFile(path.join(testDir, file)));
 
-    this.ui.writeLine(chalk.blue('Running Fastboot tests! This may take a while...'));
+    this.ui.writeLine(chalk.blue('Running FastBoot tests! This may take a while...'));
 
     // Run the tests.
     let run = RSVP.denodeify(mocha.run).bind(mocha);

--- a/lib/tests/setup.js
+++ b/lib/tests/setup.js
@@ -17,6 +17,12 @@ function setupTestsForFastboot(/* options */) {
       let url = requestOptions;
       if (typeof requestOptions === 'object') {
         url = requestOptions.uri || requestOptions.url;
+
+        if (requestOptions.headers
+          && requestOptions.headers.Accept
+          && requestOptions.headers.Accept.indexOf('text/html')) {
+          throw new Error('Accept header must include \'text/html\'');
+        }
       }
       if (typeof url === 'undefined') {
         throw new Error('visit helper was called without URL. Either pass a string or an object containing an `url` key.');
@@ -30,15 +36,22 @@ function setupTestsForFastboot(/* options */) {
 
       requestOptions = Object.assign({}, typeof requestOptions === 'object' ? requestOptions : {}, { url });
       delete requestOptions.uri;
+      requestOptions.headers = requestOptions.headers || {};
+      if (!requestOptions.headers.Accept) {
+        // We have to send the `Accept` header so the ember-cli server sees this as a request to `index.html` and sets
+        // `req.serveUrl`, that ember-cli-fastboot needs in its middleware
+        // See https://github.com/ember-cli/ember-cli/blob/master/lib/tasks/server/middleware/history-support/index.js#L55
+        // and https://github.com/ember-fastboot/ember-cli-fastboot/blob/master/index.js#L160
+        requestOptions.headers.Accept = 'text/html';
+      }
 
-      debug(`visiting ${url}`);
+      debug(`visiting ${url}`, requestOptions);
       return visit(requestOptions);
     };
 
     debug('Starting FastBoot server');
     app = new App(process.cwd());
     return app.startServer({
-      command: 'fastboot',
       port: port
     });
 

--- a/lib/tests/visit.js
+++ b/lib/tests/visit.js
@@ -11,8 +11,8 @@ jsdom.defaultDocumentFeatures = {
   ProcessExternalResources: false
 };
 
-function visit(url) {
-  return request(url)
+function visit(opts) {
+  return request(opts)
     .then(function(response) {
       let doc = jsdom.jsdom(response.body);
       let window = doc.defaultView;

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "debug": "^2.6.0",
     "ember-cli-addon-tests": "^0.6.0",
     "ember-cli-babel": "^5.1.7",
+    "ember-cli-version-checker": "^2.0.0",
     "jquery": "^3.1.1",
     "jsdom": "^9.10.0",
     "mocha": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1678,6 +1678,13 @@ ember-cli-version-checker@^1.0.2, ember-cli-version-checker@^1.1.4, ember-cli-ve
   dependencies:
     semver "^5.3.0"
 
+ember-cli-version-checker@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-2.0.0.tgz#e1f7d8e4cdcd752ac35f1611e4daa8836db4c4c7"
+  dependencies:
+    resolve "^1.3.3"
+    semver "^5.3.0"
+
 ember-cli@2.11.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/ember-cli/-/ember-cli-2.11.0.tgz#29461b1b3b1d7412b60dfc14e9399ba49ac9b707"
@@ -4202,6 +4209,10 @@ path-key@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-1.0.0.tgz#5d53d578019646c0d68800db4e146e6bdc2ac7af"
 
+path-parse@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
+
 path-posix@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/path-posix/-/path-posix-1.0.0.tgz#06b26113f56beab042545a23bfa88003ccac260f"
@@ -4624,6 +4635,12 @@ resolve-from@^1.0.0:
 resolve@^1.1.2, resolve@^1.1.6, resolve@^1.1.7:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.2.0.tgz#9589c3f2f6149d1417a40becc1663db6ec6bc26c"
+
+resolve@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.3.tgz#655907c3469a8680dc2de3a275a8fdd69691f0e5"
+  dependencies:
+    path-parse "^1.0.5"
 
 restore-cursor@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
`ember fastboot` is deprecated. Also workaround for https://github.com/ember-fastboot/ember-cli-fastboot/issues/386